### PR TITLE
Decouple WebKit from WindowView

### DIFF
--- a/mac-web-browser/mac-web-browser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mac-web-browser/mac-web-browser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "git@github.com:mauriciomaniglia/core-web-browser.git",
       "state" : {
         "branch" : "main",
-        "revision" : "d7b1d9079d4c2a2eeb593fdca693af0147c18884"
+        "revision" : "326b638ead39b978bd3e9b1583740c702139a0b2"
       }
     }
   ],

--- a/mac-web-browser/mac-web-browser/Window/Composition/WindowComposer.swift
+++ b/mac-web-browser/mac-web-browser/Window/Composition/WindowComposer.swift
@@ -4,10 +4,10 @@ import core_web_browser
 final class WindowComposer {
     static func composerWebView() {
         let windowController = NSApplication.shared.windows.first?.windowController as! WindowController
-        let view = WindowView()
-        let webViewProxy = WebViewProxy(webView: view.webView)
+        let webViewProxy = WebViewProxy()
+        let view = WindowView(webView: webViewProxy.webView)
         let windowPresenter = WindowPresenter()
-        let windowViewAdapter = WindowViewAdapter(webViewProxy: webViewProxy, presenter: windowPresenter)
+        let windowViewAdapter = WindowViewAdapter(webView: webViewProxy, presenter: windowPresenter)
 
         windowController.contentViewController?.view = view
         webViewProxy.delegate = windowViewAdapter

--- a/mac-web-browser/mac-web-browser/Window/Views/WindowView.swift
+++ b/mac-web-browser/mac-web-browser/Window/Views/WindowView.swift
@@ -1,15 +1,19 @@
 import Cocoa
-import WebKit
 
 public class WindowView: NSView {
-    let webView = WKWebView()
+    let webView: NSView
 
-    convenience init() {
-        self.init(frame: .init(origin: .init(x: 0, y: 0), size: .init(width: 1000, height: 500)))
+    init(webView: NSView) {
+        self.webView = webView
+        super.init(frame: .init(origin: .init(x: 0, y: 0), size: .init(width: 1000, height: 500)))
         addSubview(webView)
         setupConstraints()
     }
-    
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     private func setupConstraints() {
         webView.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
Issue: https://github.com/mauriciomaniglia/mac-web-browser/issues/1

Remove WebKit reference from WindowView class since it's not needed.